### PR TITLE
Feat/34 register page

### DIFF
--- a/src/apis/activityApi.js
+++ b/src/apis/activityApi.js
@@ -25,7 +25,7 @@ export const activityGetDetailAPI = async (activityId) => {
     if (response && response.status === 200) {
       return response.data.data
     }
-  } catch (err) {
+  } catch{
     //沒抓到
     return null
   }
@@ -45,7 +45,7 @@ export const activityGetAPI = async () => {
     if (response && response.status === 200) {
       return response.data.data
     }
-  } catch (err) {
+  } catch {
     //沒抓到
     return null
   }

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -15,6 +15,9 @@ const apiAxios = axios.create({
 
 apiAxios.interceptors.request.use(
   async function (config) {
+    if(!auth.currentUser){
+      return config
+    }
     const token = await getIdToken(auth.currentUser)
     if (token) {
       config.headers.Authorization = `Bearer ${token}`

--- a/src/views/Activity/components/ActivityDetail.vue
+++ b/src/views/Activity/components/ActivityDetail.vue
@@ -19,6 +19,7 @@ const route = useRoute()
 const userComment = ref('')
 const registerComment = ref('')
 const activityId = route.params.id
+const recentActivities = ref([])
 async function getActivityDetail(){
   const activityDetail = await activityGetDetailAPI(activityId)
 
@@ -32,6 +33,7 @@ async function getActivityDetail(){
   activity.value = activityDetail
   host.value = activityDetail.host_info
   comments.value = activityDetail.comments
+  recentActivities.value = activityDetail.recent_activities
 }
 
 
@@ -45,36 +47,9 @@ const { previewMap } = useGoogleMaps(apiKey);
 const searchQuery= ref("");
 
 
-const activity = ref({
-  id: 'unique-activity-id',
-  name: '一起去玩水', // 活動名稱
-  img_url: 'https://www.welcometw.com/wp-content/uploads/2022/06/%E7%B6%B2%E7%BE%8E%E8%80%81%E6%9C%A8@sshihhan-850x638.jpg', // 活動照片網址
-  location: '261宜蘭縣頭城鎮濱海路二段6號',
-  host_id: 'uid', // 團主 ID
-  description: "一場帶你品嘗台北美味夜市小吃的活動。",
-  max_participants: 5, // 最大人數
-  min_participants: 2, // 最小人數
-  category: 'travel',
-  status: 'ongoing', // 活動狀態    registrationOpen|onGoing|completed|cancelled
-  price: 100, // 活動費用，0 表示免費
-  pay_type: 'free', // 付款方式 free|AA|host
-  require_approval: true, // 是否需要審核
-  approval_deadline: "2024-12-08T23:59:59.000Z", // 最後審核日期
-  event_time: "2024-12-08T23:59:59.000Z",
-  participants: [],
-})
+const activity = ref({})
 
 const host = ref({})
-
-const user = ref({
-  uid: 'zm5skjX4z7WTal4x6m7f6Ae0zzE2',
-  email: 'mbg@dghuifr.voh',
-  email_verified: false,
-  full_name: '張曉明',
-  display_name: '小明123',
-  phone_number: 1232312312,
-  photo_url: 'https://via.placeholder.com/150',
-})
 
 const payment = computed(() => {
   switch (activity.value.pay_type) {
@@ -90,24 +65,26 @@ const payment = computed(() => {
 })
 
 const registerCount = computed(() => {
-  return activity.value.participants.reduce((count ,application) => {
-    if(application.status == 'registered' || application.status == 'approved'){
-      count++
+  // 不用審核的用，報名人數就是validated的人數，
+  if(!activity.value.require_approval){
+    return activity.value.participants.reduce((count, application) => {
+      return count + application.register_validated
+    }, 0)
+  }
+  // 要審核的話，報名人數就是在表單裡有出現且為Registered的
+  return activity.value.particiapnts.reduce((count, application) => {
+    if(application.status === 'registered'){
+      return count++
     }
     return count
-  } ,0)
+  }, 0)
 })
 
 const clearComment = () => {
   userComment.value = ''
 }
 
-const comments = ref({
-  uid: 'zm5skjX4z7WTal4x6m7f6Ae0zzE2',
-  user_comment: '一起去吧!',
-  photo_url: 'https://via.placeholder.com/150',
-  display_name: '小明123',
-})
+const comments = ref()
 
 const showRegisterModal = ref(false)
 const toggleRegisterModal = () => {
@@ -117,7 +94,8 @@ const toggleRegisterModal = () => {
 const registerActivity = async () => {
   const data = {
     participant_id: userStore.user.uid, //這裡記得改成pinia定義的user
-    comment: registerComment.value
+    comment: registerComment.value,
+    register_validated: !activity.value.require_approval && !activity.value.require_payment ? 1 : 0
   }
   // 等登入那部份處理好
   // if(!userStore.user.isLogin){
@@ -127,7 +105,11 @@ const registerActivity = async () => {
 
   const res = await activityRegisterAPI(activityId, data)
   if(res.status !== 201){
-    message.error('報名失敗')
+    if(res.message === '報名上限已達'){
+      message.error('報名已達上限')
+    }else{
+      message.error('報名失敗')
+    }
     toggleRegisterModal()
     return
   }
@@ -150,7 +132,7 @@ const registerActivity = async () => {
 }
 // 根據活動判斷當前使用者是否為主辦者
 const isHost = computed(() => {
-  return activity.value.host_id === user.value.uid
+  return activity.value.host_id === userStore.user.uid
 })
 
 
@@ -158,7 +140,6 @@ onMounted(async() => {
   await getActivityDetail()
   searchQuery.value = activity.value.location;
   await previewMap(searchQuery.value);
-  user.value = userStore.user
 })
 // 根據抓取回來的資料判斷使用者是否已註冊該活動
 const isRegistered = computed(() => {
@@ -244,6 +225,15 @@ const submitComment = async () => {
   clearComment()
 }
 
+const addToCart = () => {
+  const data = {
+    activity_id: activity.value.id,
+    uid: userStore.user.uid
+  }
+  console.log('加到購物車', data)
+  toggleRegisterModal()
+}
+
 const options = [
   {
     label: '刪除',
@@ -268,7 +258,7 @@ const handleDropSelect = async (key, comment_id) => {
 
 </script>
 <template>
-  <div class="bg-[#E5E7EB]">
+  <div v-if="activity.id" class="bg-[#E5E7EB]">
     <div class="container" >
       <div class="detail-container">
         <div class="flex items-center mb-4 w-full">
@@ -279,7 +269,7 @@ const handleDropSelect = async (key, comment_id) => {
             <img class="w-14 aspect-square rounded-full" :src="host.photo_url" alt="">
             <div class="ml-3 relative w-full h-14">
               <p class="font-bold text-lg absolute top-0">{{ host.display_name }}</p>
-              <p class="absolute bottom-0">新北市 • 45 • 員工</p>
+              <p class="absolute bottom-0">{{`${userStore.user.city} • ${userStore.user.age} • ${userStore.user.career}`}}</p>
             </div>
           </div>
 
@@ -338,6 +328,43 @@ const handleDropSelect = async (key, comment_id) => {
             @positive-click="onCancelPositiveClick"
             @negative-click="onCancelNegativeClick"
           />
+          <n-modal
+            class="rounded-lg"
+            v-model:show="showRegisterModal"
+            :auto-focus="false"
+          >
+            <n-card
+              v-if="!activity.require_payment"
+              style="width: 500px"
+              title="報名活動"
+              :bordered="false"
+              size="huge"
+              role="dialog"
+              aria-modal="true"
+              >
+
+              <NInput :autosize="{ minRows: 3, maxRows: 5 }" :show-count="true" v-model:value="registerComment" :maxlength="50" :clearable="true" type="textarea" placeholder="告訴團主你為什麼想參加吧！"></NInput>
+              <template #footer>
+                <NButton @click="registerActivity" type="primary" round class="font-bold w-full">報名</NButton>
+                <NButton type="secondary" round class="font-bold mt-2 w-full" @click="toggleRegisterModal">取消</NButton>
+              </template>
+            </n-card>
+            <n-card 
+              v-else
+              style="width: 500px; "
+              title="報名活動"
+              :bordered="false"
+              size="huge"
+              role="dialog"
+              aria-modal="true"              
+              >  
+              該活動需要先付費完成才視同報名成功，是否將活動加入購物車？
+              <template #footer>
+                <NButton  type="primary" round class="font-bold w-full" @click="addToCart">加到購物車</NButton>
+                <NButton type="secondary" round class="font-bold mt-2 w-full" @click="toggleRegisterModal">取消</NButton>
+              </template>
+            </n-card>
+          </n-modal>
           <p class="py-8 leading-6">{{ activity.description }}</p>
           <ul class="flex justify-around text-md border border-gray-200/100 rounded-lg p-2">
             <li class="flex flex-col items-center">
@@ -395,42 +422,20 @@ const handleDropSelect = async (key, comment_id) => {
       <div class="cards-container  px-[2%] ">
         <h2 class="text-2xl font-bold mb-10">近期活動</h2>
         <ActivityCard
-          v-for="(items, index) in 5"
-          :key="index"
-
+          v-for="item in recentActivities"
+          :key="item.img_url"
           horizontal="true"
-          :title="activity.name"
-          :actImgUrl="activity.img_url"
-          :location="activity.location"
-          :dateTime="dayjs(activity.event_time).format('YYYY年MM月DD日')"
+          :title="item.name"
+          :actImgUrl="item.photo_url"
+          :location="item.location"
+          :dateTime="dayjs(item.event_time).format('YYYY年MM月DD日')"
           :participants="registerCount"
-          :host="activity.host_id"
+          :host="item.users.display_name"
           :imageHeight="'100%'"
+          :hostImgUrl="item.users.photo_url"
           class="mb-[3%] h-36"
         ></ActivityCard>
       </div>
-      <NModal
-        class="rounded-lg"
-        v-model:show="showRegisterModal"
-        :auto-focus="false"
-      >
-        <n-card
-          style="width: 500px"
-          title="報名活動"
-          :bordered="false"
-          size="huge"
-          role="dialog"
-          aria-modal="true"
-        >
-
-          <NInput :autosize="{ minRows: 3, maxRows: 5 }" :show-count="true" v-model:value="registerComment" :maxlength="50" :clearable="true" type="textarea" placeholder="告訴團主你為什麼想參加吧！"></NInput>
-          <template #footer>
-            <NButton @click="registerActivity" type="primary" round class="font-bold w-full">報名</NButton>
-            <NButton type="secondary" round class="font-bold mt-2 w-full" @click="toggleRegisterModal">取消</NButton>
-          </template>
-        </n-card>
-      </NModal>
-
     </div>
   </div>
 

--- a/src/views/Activity/components/ActivityDetail.vue
+++ b/src/views/Activity/components/ActivityDetail.vue
@@ -287,7 +287,8 @@ const handleDropSelect = async (key, comment_id) => {
           <p v-if="activity.status === 'registrationOpen'" class="font-bold text-lg text-end">{{ `${registerCount}人報名` }}</p>
           <div v-if="activity.status === 'registrationOpen'">
             <div v-if="isHost">
-              <NButton  class="w-full mt-3 font-bold text-lg py-5" round type="primary" @click="toggleReviewModal">審核</NButton>
+              <NButton v-if="activity.require_approval" class="w-full mt-3 font-bold text-lg py-5" round type="primary" @click="toggleReviewModal">審核報名</NButton>
+              <NButton v-else class="w-full mt-3 font-bold text-lg py-5" round type="primary" @click="toggleReviewModal">瀏覽報名</NButton>
               <NButton  class="w-full mt-3 font-bold text-lg py-5" round type="warning" @click="toggleCancelModal">取消活動</NButton>
             </div>
             <div v-else>

--- a/src/views/Activity/components/ActivityDetail.vue
+++ b/src/views/Activity/components/ActivityDetail.vue
@@ -10,7 +10,7 @@ import ActivityCard from '@/views/components/ActivityCard.vue';
 import router from '@/router';
 import { useRoute } from 'vue-router';
 import { useUserStore } from '@/stores/userStore';
-import { activityCancelRegisterAPI, activityGetDetailAPI, activityRegisterAPI, activityCancelAPI, activityNewCommentAPI, activityDeleteCommentAPI } from '@/apis/activityApi';
+import { activityCancelRegisterAPI, activityGetDetailAPI, activityRegisterAPI, activityCancelAPI, activityNewCommentAPI, activityDeleteCommentAPI } from '@/apis/activityApi.js';
 import { useSocketStore } from '@/stores/socketStore';
 
 dayjs.locale('zh-tw')
@@ -67,12 +67,12 @@ const payment = computed(() => {
 const registerCount = computed(() => {
   // 不用審核的用，報名人數就是validated的人數，
   if(!activity.value.require_approval){
-    return activity.value.participants.reduce((count, application) => {
+    return activity.value.applications.reduce((count, application) => {
       return count + application.register_validated
     }, 0)
   }
   // 要審核的話，報名人數就是在表單裡有出現且為Registered的
-  return activity.value.particiapnts.reduce((count, application) => {
+  return activity.value.applications.reduce((count, application) => {
     if(application.status === 'registered'){
       return count++
     }
@@ -285,7 +285,7 @@ const handleDropSelect = async (key, comment_id) => {
           </div>
           <span class="text-sm text-red-500">{{ `最後審核時間 ${dayjs(activity.approval_deadline).format('YYYY年MM月DD日dddd HH:mm')}` }}</span>
           <p v-if="activity.status === 'registrationOpen'" class="font-bold text-lg text-end">{{ `${registerCount}人報名` }}</p>
-          <div v-if="activity.status === 'registrationOpen'">
+          <div v-if="activity.status === 'registrationOpen' ">
             <div v-if="isHost">
               <NButton v-if="activity.require_approval" class="w-full mt-3 font-bold text-lg py-5" round type="primary" @click="toggleReviewModal">審核報名</NButton>
               <NButton v-else class="w-full mt-3 font-bold text-lg py-5" round type="primary" @click="toggleReviewModal">瀏覽報名</NButton>

--- a/src/views/Activity/components/ActivityDetail.vue
+++ b/src/views/Activity/components/ActivityDetail.vue
@@ -74,7 +74,7 @@ const registerCount = computed(() => {
   // 要審核的話，報名人數就是在表單裡有出現且為Registered的
   return activity.value.applications.reduce((count, application) => {
     if(application.status === 'registered'){
-      return count++
+      return ++count
     }
     return count
   }, 0)
@@ -91,17 +91,14 @@ const toggleRegisterModal = () => {
   showRegisterModal.value = !showRegisterModal.value
 }
 
+// 只有不用付款的報名會跑到這個function
 const registerActivity = async () => {
   const data = {
-    participant_id: userStore.user.uid, //這裡記得改成pinia定義的user
+    participant_id: userStore.user.uid, 
     comment: registerComment.value,
-    register_validated: !activity.value.require_approval && !activity.value.require_payment ? 1 : 0
+    // 不需要審核的話，報名即視為認證報名
+    register_validated: !activity.value.require_approval  ? 1 : 0
   }
-  // 等登入那部份處理好
-  // if(!userStore.user.isLogin){
-  //   alert('請先登入')
-  //   return
-  // }
 
   const res = await activityRegisterAPI(activityId, data)
   if(res.status !== 201){


### PR DESCRIPTION
敘述：
  活動目前分為四種狀態，是否審核以及是否需要付費，因應接下來的金流功能修正報名功能

修正：
  - 刪除activity api用不到的程式碼


新增功能：
  - 判斷活動是否需要審核以及付費
  - 根據上述狀態顯示不同情況
  - 搭配後端，根據不需審核且免費、不需審核且需付費的情況設定報名上限，並顯示於使用者
  - 如進入活動詳情頁面的是團主，根據是否需要審核將按鈕更正為瀏覽報名或審核報名 (都是去審核頁面，審核頁面可能可以做一個純顯示，不能審核的狀態)
  - 抓取近期活動(依照時間，最近的15筆)
 
如需付費
<img width="838" alt="截圖 2024-12-18 下午2 55 41" src="https://github.com/user-attachments/assets/179a4a7f-2116-46b4-8d8e-51f7f9cff715" />

如不需付費
<img width="1126" alt="截圖 2024-12-18 下午2 56 29" src="https://github.com/user-attachments/assets/7dca0051-7f81-40c6-8fff-b9a2d7334386" />

如該活動不需審核，團主進入詳情頁面時
<img width="457" alt="截圖 2024-12-18 下午3 29 20" src="https://github.com/user-attachments/assets/a0d75401-39f6-4949-95d4-a5f130f525d3" />

如需審核，團主進入詳情頁面時
<img width="498" alt="截圖 2024-12-18 下午3 30 17" src="https://github.com/user-attachments/assets/aceacc0f-da78-4afe-91ec-5652274192e4" />
