### PR TITLE
refator: move Google API call to backend and resolve google lint error

### DIFF
--- a/src/apis/activityApi.js
+++ b/src/apis/activityApi.js
@@ -170,3 +170,11 @@ export const activityUserCreateAPI = async (file, otherData) => {
     throw error // 重新拋出錯誤以便處理
   }
 }
+
+export const activityAutocompleteAPI = async (query) => {
+  return await apiAxios.post('/activities/autocomplete', { query });
+};
+
+export const activityGeocodeAPI = async (address) => {
+  return await apiAxios.post('/activities/geocode', { address });
+};

--- a/src/stores/useAutocomplete.js
+++ b/src/stores/useAutocomplete.js
@@ -1,85 +1,47 @@
-import { ref } from 'vue'
-import { loadGoogleMapsAPI } from '@/utils/googleMapsLoader'
-import debounce from 'lodash/debounce'
-import { useMessage } from 'naive-ui'
+import { ref } from 'vue';
+import debounce from 'lodash/debounce';
+import { useMessage } from 'naive-ui';
+import { activityAutocompleteAPI } from '@/apis/activityAPI';
 
-export function useAutocomplete(apiKey) {
-  const searchQuery = ref('')
-  const suggestions = ref([])
-  const autocompleteInstance = ref(null)
-  const isLoading = ref(false)
-  const isLoadOK = ref(false)
-  const isLoadSearch = ref(false)
-  const message = useMessage()
+export function useAutocomplete() {
+  const searchQuery = ref('');
+  const suggestions = ref([]);
+  const isLoading = ref(false);
+  const isLoadOK = ref(false);
+  const message = useMessage();
 
-  const initializeAutocomplete = async () => {
-    try {
-      isLoading.value = true
-      isLoadSearch.value = true
-    } catch {
-      isLoading.value = false // 如果失敗，設置為 false
-    }
-
-    if (!autocompleteInstance.value) {
-      const googleMaps = await loadGoogleMapsAPI(apiKey)
-      autocompleteInstance.value = new googleMaps.places.AutocompleteService()
-    }
-  }
-
-  const fetchSuggestions = () => {
-    if (!autocompleteInstance.value || !searchQuery.value) {
-      suggestions.value = []
-      isLoading.value = false
-      return
-    }
-  }
   const onInputChange = debounce(async () => {
-    if (!autocompleteInstance.value || !searchQuery.value) {
-      suggestions.value = []
-      isLoading.value = false
-      return
+    if (!searchQuery.value) {
+      suggestions.value = [];
+      isLoading.value = false;
+      return;
     }
 
-    suggestions.value = []
-
-    autocompleteInstance.value.getPlacePredictions(
-      {
-        input: searchQuery.value,
-        types: ['geocode'],
-        language: 'zh-TW',
-        componentRestrictions: { country: 'TW' },
-      },
-      (predictions, status) => {
-        isLoading.value = false
-        if (status === google.maps.places.PlacesServiceStatus.OK) {
-          suggestions.value = predictions || []
-          isLoadOK.value = true
-        } else {
-          suggestions.value = []
-          message.warning('未搜尋到地址，請重新輸入')
-          isLoadOK.value = false
-          isLoading.value = false
-          searchQuery.value = null
-        }
-      },
-    )
-  }, 2000)
+    isLoading.value = true;
+    try {
+      const response = await activityAutocompleteAPI(searchQuery.value);
+      suggestions.value = response.data.predictions || [];
+      isLoadOK.value = true;
+    } catch (error) {
+      console.error('Autocomplete 錯誤:', error);
+      message.warning('未搜尋到地址，請重新輸入');
+      isLoadOK.value = false;
+    } finally {
+      isLoading.value = false;
+    }
+  }, 500);
 
   const triggerInputChange = () => {
-    isLoading.value = true
-    isLoadOK.value = false
-    onInputChange()
-  }
+    isLoadOK.value = false;
+    onInputChange();
+  };
 
   return {
     searchQuery,
     suggestions,
     onInputChange,
     triggerInputChange,
-    initializeAutocomplete,
-    fetchSuggestions,
     isLoading,
     isLoadOK,
-    isLoadSearch,
-  }
+  };
 }

--- a/src/stores/useGoogleMaps.js
+++ b/src/stores/useGoogleMaps.js
@@ -1,49 +1,48 @@
-import { ref, nextTick } from 'vue'
-import { loadGoogleMapsAPI } from '@/utils/googleMapsLoader'
+import { ref, nextTick } from 'vue';
+import { activityGeocodeAPI } from '@/apis/activityAPI';
+import { loadGoogleMapsAPI } from '@/utils/googleMapsLoader';
 
-export function useGoogleMaps(apiKey) {
-  const map = ref(null)
-  const geocoder = ref(null)
+/* global google */
+
+export function useGoogleMaps() {
+  const map = ref(null);
+  const apiKey = import.meta.env.VITE_GOOGLE_KEY
 
   const previewMap = async (searchQuery) => {
-    if (!searchQuery) return // 若搜尋查詢為空則返回
+    if (!searchQuery) return;
 
-    const googleMaps = await loadGoogleMapsAPI(apiKey)
-    if (!geocoder.value) {
-      geocoder.value = new googleMaps.Geocoder() // 初始化地理編碼器
-    }
+    try {
+      const response = await activityGeocodeAPI(searchQuery);
+      const location = response.data.location;
 
-    geocoder.value.geocode({ address: searchQuery }, (results, status) => {
-      if (status === 'OK' && results[0]) {
-        const location = results[0].geometry.location
+      await loadGoogleMapsAPI(apiKey)
 
         nextTick(() => {
-          const mapElement = document.getElementById('map')
-          if (!mapElement) {
-            console.error('地圖容器元素未找到')
-            return
-          }
+        const mapElement = document.getElementById('map');
+        if (!mapElement) {
+          return;
+        }
 
-          map.value = new googleMaps.Map(mapElement, {
-            center: location,
-            zoom: 14,
-          })
-          new googleMaps.Marker({
-            map: map.value,
-            position: location,
-          })
-        })
-      } else {
-        console.error('地址無法解析為地圖位置', status)
-      }
-    })
-  }
+      // 初始化Google Maps
+        map.value = new google.maps.Map(mapElement, {
+          center: location,
+          zoom: 14,
+        });
+        new google.maps.Marker({
+          map: map.value,
+          position: location,
+        });
+      });
+    } catch{
+      return
+    }
+  };
 
   const clearMap = () => {
     if (map.value) {
-      map.value = null
+      map.value = null;
     }
-  }
+  };
 
-  return { map, geocoder, previewMap, clearMap }
+  return { map, previewMap, clearMap };
 }

--- a/src/stores/usePreviewMode.js
+++ b/src/stores/usePreviewMode.js
@@ -1,19 +1,21 @@
-import { ref, nextTick } from 'vue'
+import { ref, nextTick } from 'vue';
 
 export function usePreviewMode(previewMap) {
-  const isPreviewMode = ref(false)
+  const isPreviewMode = ref(false);
 
   const enterPreviewMode = (searchQuery) => {
-    isPreviewMode.value = true // 設置預覽模式為開啟
-    previewMap(searchQuery) // 傳遞 searchQuery 給 previewMap
-  }
+    if (!searchQuery) {
+      return;
+    }
+    isPreviewMode.value = true; // 設置預覽模式為開啟
+    previewMap(searchQuery); // 傳遞 searchQuery 給 previewMap
+  };
 
   const exitPreviewMode = () => {
     nextTick(() => {
-      isPreviewMode.value = false
-      // 如果 map.value 存在，則清除地圖實例
-    })
-  }
+      isPreviewMode.value = false;
+    });
+  };
 
-  return { isPreviewMode, enterPreviewMode, exitPreviewMode }
+  return { isPreviewMode, enterPreviewMode, exitPreviewMode };
 }

--- a/src/utils/googleMapsLoader.js
+++ b/src/utils/googleMapsLoader.js
@@ -1,7 +1,7 @@
 let isAPILoaded = false
 let onLoadCallbacks = []
 
-// 動態載入 Google Maps API
+// 動態渲染google 地圖
 export const loadGoogleMapsAPI = (apiKey, libraries = 'places', language = 'zh-TW') => {
   return new Promise((resolve, reject) => {
     if (isAPILoaded) {
@@ -24,7 +24,7 @@ export const loadGoogleMapsAPI = (apiKey, libraries = 'places', language = 'zh-T
         onLoadCallbacks = []
       }
       script.onerror = () => {
-        reject(new Error('Failed to load Google Maps API'))
+        reject(new Error('Google Maps API 加載失敗'))
       }
       document.head.appendChild(script)
     }

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -3,7 +3,7 @@ import { getIdToken } from 'firebase/auth'
 import { auth } from './firebaseConfig'
 
 const apiAxios = axios.create({
-  baseURL: 'https://joitogetherbackend-production-5e45.up.railway.app/',
+  baseURL: 'http://localhost:3030/',
   timeout: 5000,
 })
 //

--- a/src/views/Activity/components/ActivityDetail.vue
+++ b/src/views/Activity/components/ActivityDetail.vue
@@ -17,7 +17,7 @@ import {
   activityCancelAPI,
   activityNewCommentAPI,
   activityDeleteCommentAPI,
-} from '@/apis/activityApi.js'
+} from '@/apis/activityAPI.js'
 import { useSocketStore } from '@/stores/socketStore'
 
 dayjs.locale('zh-tw')

--- a/src/views/Activity/components/ActivityReview.vue
+++ b/src/views/Activity/components/ActivityReview.vue
@@ -16,7 +16,7 @@ import {
   ActivityGetApplicationsAPI,
   ActivityReviewApplicationsAPI,
   ActivityGetActivitiesAPI,
-} from '@/apis/activityApi'
+} from '@/apis/activityAPI'
 import { useRoute } from 'vue-router'
 import { useUserStore } from '@/stores/userStore'
 

--- a/src/views/Home/components/ActivityComponent.vue
+++ b/src/views/Home/components/ActivityComponent.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ActivityCard from '@/views/components/ActivityCard.vue'
-import { activityGetAllAPI, activityGetUsersAPI } from '@/apis/activityAPi.js'
+import { activityGetAllAPI, activityGetUsersAPI } from '@/apis/activityAPI.js'
 import { ref, onMounted, computed, onUnmounted, nextTick } from 'vue'
 import { formatToISOWithTimezone } from '@/stores/useDateTime'
 


### PR DESCRIPTION
1.修正lint google 錯誤問題
會未宣告是因為Google Map 的資訊是在 創建活動後才會執行。
將google 在.eslintrc.js 宣告為全域只讀變數就不會跳通知。

2.將google 搜尋地址api 移動到後端寫兩支post方法
('/activities/autocomplete', { query });  搜尋地址
('/activities/geocode', { address }); 代會地址座標參數

![image](https://github.com/user-attachments/assets/d0ff3269-f152-4089-8637-675fddb7d63d)