### PR TITLE
feat: Add city-based activity search on homepage #48

### DIFF
--- a/src/views/Home/components/ActivityComponent.vue
+++ b/src/views/Home/components/ActivityComponent.vue
@@ -1,8 +1,36 @@
 <script setup>
 import ActivityCard from '@/views/components/ActivityCard.vue'
 import { activityGetAllAPI, activityGetUsersAPI } from '@/apis/activityAPi.js'
-import { ref, onMounted, computed, onUnmounted, nextTick } from 'vue'
+import { ref, onMounted, computed, onUnmounted, nextTick, inject } from 'vue'
 import { formatToISOWithTimezone } from '@/stores/useDateTime'
+import { NSelect } from 'naive-ui'
+
+// 注入來自 BannerComponent 的 selectedRegion
+const selectedRegions = inject('selectedRegion')
+
+// 地區選項
+const regionOptions = ref([
+  { label: '台北', value: '台北市' },
+  { label: '新北', value: '新北市' },
+  { label: '基隆', value: '基隆市' },
+  { label: '新竹', value: '新竹市' },
+  { label: '桃園', value: '桃園市' },
+  { label: '新竹', value: '新竹縣' },
+  { label: '宜蘭', value: '宜蘭縣' },
+  { label: '臺中', value: '臺中市' },
+  { label: '苗栗', value: '苗栗縣' },
+  { label: '彰化', value: '彰化縣' },
+  { label: '南投', value: '南投縣' },
+  { label: '雲林', value: '雲林縣' },
+  { label: '高雄', value: '高雄市' },
+  { label: '臺南', value: '臺南市' },
+  { label: '嘉義', value: '嘉義市' },
+  { label: '嘉義', value: '嘉義縣' },
+  { label: '屏東', value: '屏東縣' },
+  { label: '澎湖', value: '澎湖縣' },
+  { label: '花蓮', value: '花蓮縣' },
+  { label: '臺東', value: '臺東縣' },
+])
 
 const allActivities = ref([]) // 存放所有活動資料（未篩選）
 const userMap = ref({})
@@ -34,9 +62,17 @@ const filteredItems = computed(() => {
 
   return allActivities.value
     .filter((activity) => {
+      const location = activity.location ||''
       const eventDate = new Date(activity.event_time)
       if (eventDate < today) return false
       if (eventDate < startFilterDate) return false
+       // 多地區篩選邏輯
+      if (selectedRegions.value.length > 0) {
+      const matchRegion = selectedRegions.value.some((region) =>
+        location.includes(region.toLowerCase())
+      )
+      if (!matchRegion) return false
+      }
       if (selectedCategory.value && activity.category !== selectedCategory.value) return false
       return true
     })
@@ -191,7 +227,14 @@ onUnmounted(() => {
     <!-- 篩選器 -->
     <div class="mt-7 flex justify-between items-center">
       <div class="text-xl flex items-center">
-        <span class="ml-1"></span>
+        <n-select
+      v-model:value="selectedRegions"
+      :options="regionOptions"
+      multiple
+      clearable
+      placeholder="選擇地區"
+      style="width: 200px; margin-right: 16px;"
+    />
       </div>
       <div class="text-xl flex items-center">
         篩選日期

--- a/src/views/Home/components/BannerComponent.vue
+++ b/src/views/Home/components/BannerComponent.vue
@@ -14,10 +14,11 @@
           <h1>熱門聚會地點</h1>
           <div class="flex items-center w-full justify-evenly">
             <div v-for="aria in ariaData" :key="aria.title">
-              <a href="#">
+              <button
+              @click="setRegion(aria.keyword)">
                 <img :src="aria.src" alt="" />
                 <p class="text-center">{{ aria.title }}</p>
-              </a>
+              </button>
             </div>
           </div>
         </div>
@@ -28,6 +29,15 @@
 
 <script setup>
 import { NCarousel } from 'naive-ui'
+import { inject } from 'vue';
+
+const selectedRegions = inject('selectedRegion')
+
+const setRegion = (region) => {
+  if (!selectedRegions.value.includes(region)) {
+    selectedRegions.value.push(region)
+  }
+}
 
 const carouselData = [
   {
@@ -44,26 +54,32 @@ const carouselData = [
 const ariaData = [
   {
     title: '大台北',
+    keyword: '台北',
     src: 'https://www.eatgether.com/static/media/TPE.91790170.png',
   },
   {
     title: '桃園市',
+    keyword: '桃園',
     src: 'https://www.eatgether.com/static/media/TAO.68ddb6e3.png',
   },
   {
     title: '新竹市',
+    keyword: '新竹',
     src: 'https://www.eatgether.com/static/media/HSZ.417cf6b8.png',
   },
   {
     title: '臺中市',
+    keyword: '臺中',
     src: 'https://www.eatgether.com/static/media/TXG.c136bf99.png',
   },
   {
     title: '臺南市',
+    keyword: '臺南',
     src: 'https://www.eatgether.com/static/media/TNN.1ab27f99.png',
   },
   {
     title: '高雄市',
+    keyword: '高雄',
     src: 'https://www.eatgether.com/static/media/KHH.da56765a.png',
   },
 ]
@@ -75,13 +91,13 @@ const ariaData = [
   height: 450px;
   object-fit: cover;
 }
-a img {
+button img {
   border-radius: 50%;
   max-width: 100px;
   height: auto;
   margin: 0 auto;
 }
-a img:hover {
+button img:hover {
   transform: scale(1.05);
   transition: transform 0.3s ease-in-out;
 }

--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -5,7 +5,13 @@ import PostComponent from './components/PostComponent.vue'
 import ActivityComponent from './components/ActivityComponent.vue'
 import { useUserStore } from '/src/stores/userStore.js'
 import { useMessage } from 'naive-ui'
-import { watch, ref, onMounted } from 'vue'
+import { watch, ref, onMounted, provide } from 'vue'
+
+// 創建地區共享的響應式變數
+const selectedRegions = ref([])
+
+// 使用 provide 提供給子組件
+provide('selectedRegion', selectedRegions)
 
 // 初始化區域
 const userStore = useUserStore()


### PR DESCRIPTION
feat: 首頁城市活動搜尋 #48

- 新增 regionOptions 地區選項：
  - 分組包含北部、中部、南部及東部所有地區。
- 支援多地區篩選邏輯：
  - 根據 `selectedRegions` 動態篩選活動列表。
  - 按城市地址包含關鍵字篩選。
- 更新 `n-select`：
  - 分組顯示地區選項，支援多選及清除功能。
- 點擊 Banner 按鈕同步更新：
  - 點擊「大台北」或「桃園」等按鈕自動將城市添加至篩選條件。
  - 確保活動列表即時更新。
- 測試功能：
  - 確認多選和篩選功能正常運作。
  - 確保活動列表根據多條件篩選正確渲染。